### PR TITLE
Fix variable assignment to include all grep matches

### DIFF
--- a/format-code.sh
+++ b/format-code.sh
@@ -8,6 +8,6 @@ then
 fi
 cd ..
 
-changed_java_files=($(git diff --cached --name-only --diff-filter=ACMR | grep ".*java$" ))
+changed_java_files=$(git diff --cached --name-only --diff-filter=ACMR | grep ".*java$" )
 echo $changed_java_files
 java -jar .cache/google-java-format-1.5-all-deps.jar --replace $changed_java_files


### PR DESCRIPTION
Currently the variable is only assigned the first matching value so the formatter runs only on that file