### PR TITLE
Switch from `files` to `types`

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,5 +3,5 @@
     description: Formats code in Google's Java codestyle.
     entry: ./format-code.sh
     language: script
-    files: \.java$ # We don't technically need this, as the script will filter for us, but this will allow the hook to be skipped if no Java is changed.
+    types: [java] # We don't technically need this, as the script will filter for us, but this will allow the hook to be skipped if no Java is changed.
 


### PR DESCRIPTION
types is slightly less error-prone, and for languages which support shebangs (sorry java) it can enable linting of extensionless executables