### PR TITLE
Fix yaml formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ Usage:
 repos:
 - repo: https://github.com/maltzj/google-style-precommit-hook
   sha: b7e9e7fcba4a5aea463e72fe9964c14877bd8130
-    hooks:
-      - id: google-style-java
+  hooks:
+    - id: google-style-java
 ```
 
 *Note*: this file stores Google's code style formatter jar in a `.cache/`


### PR DESCRIPTION
Fixing the indentation so that `pre-commit` does not abort operation with error:

> pre-commit-config.yaml mapping values are not allowed in this context