### PR TITLE
README: Changed `sha` to `rev`, and indentation fix 

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ Usage:
 ```
 repos:
 - repo: https://github.com/maltzj/google-style-precommit-hook
-  sha: b7e9e7fcba4a5aea463e72fe9964c14877bd8130
-    hooks:
-      - id: google-style-java
+  rev: b7e9e7fcba4a5aea463e72fe9964c14877bd8130
+  hooks:
+    - id: google-style-java
 ```
 
 *Note*: this file stores Google's code style formatter jar in a `.cache/`


### PR DESCRIPTION
As specified in the docs, `sha` has changed to `rev`:
See:
https://pre-commit.com/#pre-commit-configyaml---repos