### PR TITLE
update example to work with latest version of pre-commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ Usage:
 
 ```
 repos:
-- repo: https://github.com/maltzj/google-style-precommit-hook
-  rev: 95c2f5632710e095220e22cc1a4e1a1451abf75f
+- repo: https://github.com/0x08/google-style-precommit-hook
+  rev: 8a61d5fda43e9a1ce12e46aa073380e29b4ec340
   hooks:
     - id: google-style-java
 ```

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ Usage:
 ```
 repos:
 - repo: https://github.com/maltzj/google-style-precommit-hook
-  sha: b7e9e7fcba4a5aea463e72fe9964c14877bd8130
-    hooks:
-      - id: google-style-java
+  rev: 95c2f5632710e095220e22cc1a4e1a1451abf75f
+  hooks:
+    - id: google-style-java
 ```
 
 *Note*: this file stores Google's code style formatter jar in a `.cache/`

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Usage:
 ```
 repos:
 - repo: https://github.com/0x08/google-style-precommit-hook
-  rev: 8a61d5fda43e9a1ce12e46aa073380e29b4ec340
+  rev: 503fa7c491becee130be17a10b03b275ce6f2330
   hooks:
     - id: google-style-java
 ```

--- a/format-code.sh
+++ b/format-code.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env sh
 mkdir -p .cache
 cd .cache
-if [ ! -f google-java-format-1.7-all-deps.jar ]
+if [ ! -f google-java-format-1.17.0-all-deps.jar ]
 then
-    curl -LJO "https://github.com/google/google-java-format/releases/download/google-java-format-1.7/google-java-format-1.7-all-deps.jar"
-    chmod 755 google-java-format-1.7-all-deps.jar
+    curl -LJO "https://github.com/google/google-java-format/releases/download/v1.17.0/google-java-format-1.17.0-all-deps.jar"
+    chmod 755 google-java-format-1.17.0-all-deps.jar
 fi
 cd ..
 
 changed_java_files=$(git diff --cached --name-only --diff-filter=ACMR | grep ".*java$" )
 echo $changed_java_files
-java -jar .cache/google-java-format-1.7-all-deps.jar --replace $changed_java_files
+java -jar .cache/google-java-format-1.17.0-all-deps.jar --replace $changed_java_files

--- a/format-code.sh
+++ b/format-code.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env sh
 mkdir -p .cache
 cd .cache
-if [ ! -f google-java-format-1.17.0-all-deps.jar ]
+if [ ! -f google-java-format-1.22.0-all-deps.jar ]
 then
-    curl -LJO "https://github.com/google/google-java-format/releases/download/v1.17.0/google-java-format-1.17.0-all-deps.jar"
-    chmod 755 google-java-format-1.17.0-all-deps.jar
+    curl -LJO "https://github.com/google/google-java-format/releases/download/v1.22.0/google-java-format-1.22.0-all-deps.jar"
+    chmod 755 google-java-format-1.22.0-all-deps.jar
 fi
 cd ..
 
 changed_java_files=$(git diff --cached --name-only --diff-filter=ACMR | grep ".*java$" )
 echo $changed_java_files
-java -jar .cache/google-java-format-1.17.0-all-deps.jar --replace $changed_java_files
+java -jar .cache/google-java-format-1.22.0-all-deps.jar --replace $changed_java_files


### PR DESCRIPTION
The current example does not work properly with the latest version of pre-commit, sha was replaced by rev. Also updated to the latest version of the repository.