### PR TITLE
Update README.md to point to later sha

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Usage:
 ```
 repos:
 - repo: https://github.com/maltzj/google-style-precommit-hook
-  sha: b7e9e7fcba4a5aea463e72fe9964c14877bd8130
+  sha: 95c2f5632710e095220e22cc1a4e1a1451abf75f
     hooks:
       - id: google-style-java
 ```


### PR DESCRIPTION
This will make sure people use the latest version of the formatter as well as syncing past https://github.com/maltzj/google-style-precommit-hook/commit/9442193153e6a6ee7d32c00f1132c9da64206402