### PR TITLE
Update google-java-format to 1.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
+# google-style-precommit-hook
+
 A handy [pre-commit](http://pre-commit.com/) hook which will run Google's java
 code style formatter for you on your code!
 
 Usage:
 
-```
+```yaml
 repos:
 - repo: https://github.com/maltzj/google-style-precommit-hook
   sha: b7e9e7fcba4a5aea463e72fe9964c14877bd8130

--- a/format-code.sh
+++ b/format-code.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env sh
+VERSION=1.8
 mkdir -p .cache
 cd .cache
-if [ ! -f google-java-format-1.7-all-deps.jar ]
+if [ ! -f google-java-format-$VERSION-all-deps.jar ]
 then
-    curl -LJO "https://github.com/google/google-java-format/releases/download/google-java-format-1.7/google-java-format-1.7-all-deps.jar"
-    chmod 755 google-java-format-1.7-all-deps.jar
+    curl -LJO "https://github.com/google/google-java-format/releases/download/google-java-format-$VERSION/google-java-format-$VERSION-all-deps.jar"
 fi
 cd ..
 
 changed_java_files=$(git diff --cached --name-only --diff-filter=ACMR | grep ".*java$" )
 echo $changed_java_files
-java -jar .cache/google-java-format-1.7-all-deps.jar --replace $changed_java_files
+java -jar .cache/google-java-format-$VERSION-all-deps.jar --replace $changed_java_files


### PR DESCRIPTION
Also made it easier to update in the future using a single variable. A jar file is not executable (removed chmod command).