### PR TITLE
Use the list of files supplied by pre-commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ repos:
   sha: b7e9e7fcba4a5aea463e72fe9964c14877bd8130
     hooks:
       - id: google-style-java
+        files: \.java$
 ```
 
 *Note*: this file stores Google's code style formatter jar in a `.cache/`

--- a/format-code.sh
+++ b/format-code.sh
@@ -3,7 +3,7 @@ mkdir -p .cache
 cd .cache
 if [ ! -f google-java-format-1.16.0-all-deps.jar ]
 then
-    curl -LJO "https://github.com/google/google-java-format/releases/download/v1.15.0/google-java-format-1.15.0-all-deps.jar"
+    curl -LJO "https://github.com/google/google-java-format/releases/download/v1.16.0/google-java-format-1.16.0-all-deps.jar"
     chmod 755 google-java-format-1.16.0-all-deps.jar
 fi
 cd ..

--- a/format-code.sh
+++ b/format-code.sh
@@ -8,4 +8,15 @@ then
 fi
 cd ..
 
-java -jar .cache/google-java-format-1.13.0-all-deps.jar --replace $@
+java \ 
+--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
+--add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
+--add-exports jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED \
+--add-exports jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED \
+--add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
+--add-exports jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED \
+--add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
+--add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED \
+--add-opens jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED \
+--add-opens jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED \
+-jar .cache/google-java-format-1.13.0-all-deps.jar --replace $@

--- a/format-code.sh
+++ b/format-code.sh
@@ -8,6 +8,4 @@ then
 fi
 cd ..
 
-changed_java_files=$(git diff --cached --name-only --diff-filter=ACMR | grep ".*java$" )
-echo $changed_java_files
-java -jar .cache/google-java-format-1.7-all-deps.jar --replace $changed_java_files
+java -jar .cache/google-java-format-1.7-all-deps.jar --replace $@

--- a/format-code.sh
+++ b/format-code.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env sh
 mkdir -p .cache
 cd .cache
-if [ ! -f google-java-format-1.7-all-deps.jar ]
+if [ ! -f google-java-format-1.13.0-all-deps.jar ]
 then
-    curl -LJO "https://github.com/google/google-java-format/releases/download/google-java-format-1.7/google-java-format-1.7-all-deps.jar"
-    chmod 755 google-java-format-1.7-all-deps.jar
+    curl -LJO "https://github.com/google/google-java-format/releases/download/v1.13.0/google-java-format-1.13.0-all-deps.jar"
+    chmod 755 google-java-format-1.13.0-all-deps.jar
 fi
 cd ..
 
-java -jar .cache/google-java-format-1.7-all-deps.jar --replace $@
+java -jar .cache/google-java-format-1.13.0-all-deps.jar --replace $@

--- a/format-code.sh
+++ b/format-code.sh
@@ -1,22 +1,11 @@
 #!/usr/bin/env sh
 mkdir -p .cache
 cd .cache
-if [ ! -f google-java-format-1.14.0-all-deps.jar ]
+if [ ! -f google-java-format-1.15.0-all-deps.jar ]
 then
-    curl -LJO "https://github.com/google/google-java-format/releases/download/v1.14.0/google-java-format-1.14.0-all-deps.jar"
-    chmod 755 google-java-format-1.14.0-all-deps.jar
+    curl -LJO "https://github.com/google/google-java-format/releases/download/v1.15.0/google-java-format-1.15.0-all-deps.jar"
+    chmod 755 google-java-format-1.15.0-all-deps.jar
 fi
 cd ..
 
-java \
---add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
---add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
---add-exports jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED \
---add-exports jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED \
---add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
---add-exports jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED \
---add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
---add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED \
---add-opens jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED \
---add-opens jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED \
--jar .cache/google-java-format-1.14.0-all-deps.jar --replace $@
+java -jar .cache/google-java-format-1.15.0-all-deps.jar --replace $@

--- a/format-code.sh
+++ b/format-code.sh
@@ -3,8 +3,8 @@ mkdir -p .cache
 cd .cache
 if [ ! -f google-java-format-1.13.0-all-deps.jar ]
 then
-    curl -LJO "https://github.com/google/google-java-format/releases/download/v1.13.0/google-java-format-1.13.0-all-deps.jar"
-    chmod 755 google-java-format-1.13.0-all-deps.jar
+    curl -LJO "https://github.com/google/google-java-format/releases/download/v1.14.0/google-java-format-1.14.0-all-deps.jar"
+    chmod 755 google-java-format-1.14.0-all-deps.jar
 fi
 cd ..
 

--- a/format-code.sh
+++ b/format-code.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 mkdir -p .cache
 cd .cache
-if [ ! -f google-java-format-1.13.0-all-deps.jar ]
+if [ ! -f google-java-format-1.14.0-all-deps.jar ]
 then
     curl -LJO "https://github.com/google/google-java-format/releases/download/v1.14.0/google-java-format-1.14.0-all-deps.jar"
     chmod 755 google-java-format-1.14.0-all-deps.jar
@@ -19,4 +19,4 @@ java \
 --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED \
 --add-opens jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED \
 --add-opens jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED \
--jar .cache/google-java-format-1.13.0-all-deps.jar --replace $@
+-jar .cache/google-java-format-1.14.0-all-deps.jar --replace $@

--- a/format-code.sh
+++ b/format-code.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env sh
 mkdir -p .cache
 cd .cache
-if [ ! -f google-java-format-1.15.0-all-deps.jar ]
+if [ ! -f google-java-format-1.16.0-all-deps.jar ]
 then
     curl -LJO "https://github.com/google/google-java-format/releases/download/v1.15.0/google-java-format-1.15.0-all-deps.jar"
-    chmod 755 google-java-format-1.15.0-all-deps.jar
+    chmod 755 google-java-format-1.16.0-all-deps.jar
 fi
 cd ..
 
-java -jar .cache/google-java-format-1.15.0-all-deps.jar --replace $@
+java -jar .cache/google-java-format-1.16.0-all-deps.jar --replace $@

--- a/format-code.sh
+++ b/format-code.sh
@@ -8,7 +8,7 @@ then
 fi
 cd ..
 
-java \ 
+java \
 --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
 --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
 --add-exports jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED \

--- a/format-code.sh
+++ b/format-code.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env sh
 mkdir -p .cache
 cd .cache
-if [ ! -f google-java-format-1.16.0-all-deps.jar ]
+if [ ! -f google-java-format-1.25.2-all-deps.jar ]
 then
-    curl -LJO "https://github.com/google/google-java-format/releases/download/v1.16.0/google-java-format-1.16.0-all-deps.jar"
-    chmod 755 google-java-format-1.16.0-all-deps.jar
+    curl -LJO "https://github.com/google/google-java-format/releases/download/v1.25.2/google-java-format-1.25.2-all-deps.jar"
+    chmod 755 google-java-format-1.25.2-all-deps.jar
 fi
 cd ..
 
-java -jar .cache/google-java-format-1.16.0-all-deps.jar --replace $@
+java -jar .cache/google-java-format-1.25.2-all-deps.jar --replace $@


### PR DESCRIPTION
pre-commit passes a list of files according the exclusion and other rules to the script. Currently `format-code.sh` doesn't respect the list, and creates its own list of files. 

This was leading to unwanted files getting formatted, for example, when merging.