### PR TITLE
Support JDK 16

### DIFF
--- a/format-code.sh
+++ b/format-code.sh
@@ -1,13 +1,14 @@
 #!/usr/bin/env sh
 mkdir -p .cache
 cd .cache
-if [ ! -f google-java-format-1.10.0-all-deps.jar ]
+if [ ! -f google-java-format-1.15.0-all-deps.jar ]
 then
-    curl -LJO "https://github.com/google/google-java-format/releases/download/v1.10.0/google-java-format-1.10.0-all-deps.jar"
-    chmod 755 google-java-format-1.10.0-all-deps.jar
+    curl -LJO "https://github.com/google/google-java-format/releases/download/v1.15.0/google-java-format-1.15.0-all-deps.jar"
+    chmod 755 google-java-format-1.15.0-all-deps.jar
 fi
 cd ..
-
+echo -n "Java version..."
+java --version
 changed_java_files=$(git diff --cached --name-only --diff-filter=ACMR | grep ".*java$" )
 echo $changed_java_files
 java \
@@ -16,4 +17,4 @@ java \
   --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
   --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
   --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED \
-  -jar .cache/google-java-format-1.10.0-all-deps.jar --replace $changed_java_files
+  -jar .cache/google-java-format-1.15.0-all-deps.jar --replace $changed_java_files

--- a/format-code.sh
+++ b/format-code.sh
@@ -1,13 +1,19 @@
 #!/usr/bin/env sh
 mkdir -p .cache
 cd .cache
-if [ ! -f google-java-format-1.7-all-deps.jar ]
+if [ ! -f google-java-format-1.10.0-all-deps.jar ]
 then
-    curl -LJO "https://github.com/google/google-java-format/releases/download/google-java-format-1.7/google-java-format-1.7-all-deps.jar"
-    chmod 755 google-java-format-1.7-all-deps.jar
+    curl -LJO "https://github.com/google/google-java-format/releases/download/v1.10.0/google-java-format-1.10.0-all-deps.jar"
+    chmod 755 google-java-format-1.10.0-all-deps.jar
 fi
 cd ..
 
 changed_java_files=$(git diff --cached --name-only --diff-filter=ACMR | grep ".*java$" )
 echo $changed_java_files
-java -jar .cache/google-java-format-1.7-all-deps.jar --replace $changed_java_files
+java \
+  --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED \
+  -jar .cache/google-java-format-1.10.0-all-deps.jar --replace $changed_java_files


### PR DESCRIPTION
* Update to latest `google-java-format-1.10.0-all-deps.jar` to support JDK 16 language features.
* Update `java` command to comply with [JEP 261: Module System](https://openjdk.java.net/jeps/261) updates to run with strict encapsulation by default.