### PR TITLE
Support JDK 17

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ Usage:
 
 ```
 repos:
-- repo: https://github.com/maltzj/google-style-precommit-hook
-  sha: b7e9e7fcba4a5aea463e72fe9964c14877bd8130
+  - repo: https://github.com/bauerjs1/google-style-precommit-hook.git
+    rev: cb7c169c4064b83762941e1c2222c8606817f7bb
     hooks:
       - id: google-style-java
 ```

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ Usage:
 
 ```
 repos:
-  - repo: https://github.com/bauerjs1/google-style-precommit-hook.git
-    rev: cb7c169c4064b83762941e1c2222c8606817f7bb
+- repo: https://github.com/maltzj/google-style-precommit-hook
+  sha: b7e9e7fcba4a5aea463e72fe9964c14877bd8130
     hooks:
       - id: google-style-java
 ```

--- a/format-code.sh
+++ b/format-code.sh
@@ -1,13 +1,23 @@
 #!/usr/bin/env sh
+
+VERSION=1.12.0
+JARFILE=google-java-format-$VERSION-all-deps.jar
+
 mkdir -p .cache
 cd .cache
-if [ ! -f google-java-format-1.7-all-deps.jar ]
+if [ ! -f $JARFILE ]
 then
-    curl -LJO "https://github.com/google/google-java-format/releases/download/google-java-format-1.7/google-java-format-1.7-all-deps.jar"
-    chmod 755 google-java-format-1.7-all-deps.jar
+    curl -LJO "https://github.com/google/google-java-format/releases/download/v$VERSION/$JARFILE"
+    chmod 755 $JARFILE
 fi
 cd ..
 
 changed_java_files=$(git diff --cached --name-only --diff-filter=ACMR | grep ".*java$" )
 echo $changed_java_files
-java -jar .cache/google-java-format-1.7-all-deps.jar --replace $changed_java_files
+java \
+  --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED \
+  -jar .cache/$JARFILE --replace $changed_java_files


### PR DESCRIPTION
Analogous to #22  :
* Update to latest `google-java-format-1.12.0-all-deps.jar` to support JDK 17 language features.
* Update `java` command to comply with [JEP 261: Module System](https://openjdk.java.net/jeps/261) updates to run with strict encapsulation by default.